### PR TITLE
updated deprecated call on shell.running()

### DIFF
--- a/gml/lib/gml.lua
+++ b/gml/lib/gml.lua
@@ -20,6 +20,7 @@ local component=require("component")
 local term=require("term")
 local computer=require("computer")
 local shell=require("shell")
+local process=require("process")
 local filesystem=require("filesystem")
 local keyboard=require("keyboard")
 local unicode=require("unicode")
@@ -96,7 +97,7 @@ function gml.loadStyle(name)
   local filepath
 
   --search for styles in working directory, running program directory, /lib /usr/lib. Just because.
-  local dirs={shell.getWorkingDirectory(),shell.running():match("^(.*/).+$"), "/lib/", "/usr/lib/"}
+  local dirs={shell.getWorkingDirectory(),process.running():match("^(.*/).+$"), "/lib/", "/usr/lib/"}
   if dirs[1]~="/" then
     dirs[1]=dirs[1].."/"
   end


### PR DESCRIPTION
Replaced shell.running() with process.running since the former is deprecated. http://ocdoc.cil.li/api:shell