### PR TITLE
Fix scrollbar in listbox position

### DIFF
--- a/gml/lib/gml.lua
+++ b/gml/lib/gml.lua
@@ -1488,7 +1488,7 @@ local function addListBox(gui,x,y,width,height,list)
   lb.scrollBar.class="listbox"
   lb.scrollBar.listBox=lb
 
-  lb.scrollBar.posY=1
+  lb.scrollBar.posY=lb.posY-lb.bodyY+1
   lb.scrollBar.height=lb.height
   lb.scrollBar.length=lb.height
 


### PR DESCRIPTION
Now position calculated properly, depends on exist of border over listbox.
In first version it works only **with border**, in my previous commit only **without border**, now both.

![Before](http://i.imgur.com/te5v8jy.png)
![Now border](http://i.imgur.com/gVNwC88.png) ![Now no border](http://i.imgur.com/Kf6R6ow.png)